### PR TITLE
Remove extra top padding when there is no header

### DIFF
--- a/EKStreamView.m
+++ b/EKStreamView.m
@@ -143,7 +143,7 @@
     }
     
     
-    CGFloat cellHeight = headerView ? headerView.bounds.size.height + cellPadding : cellPadding;
+    CGFloat cellHeight = headerView ? headerView.bounds.size.height + cellPadding : 0;
     for (int i = 0; i < numberOfColumns; i++) {
         [cellHeightsByColumn addObject:[NSMutableArray arrayWithCapacity:20]];
         [rectsForCells addObject:[NSMutableArray arrayWithCapacity:20]];

--- a/EKStreamView.m
+++ b/EKStreamView.m
@@ -112,8 +112,8 @@
     if ([delegate respondsToSelector:@selector(headerForStreamView:)]) {
         headerView = [delegate headerForStreamView:self];
         CGRect f = headerView.frame;
-        f.origin = CGPointMake(columnPadding, cellPadding);
-        f.size.width = self.bounds.size.width - columnPadding * 2;
+        f.origin = CGPointMake(0, 0);
+        f.size.width = self.bounds.size.width;
         headerView.frame = f;
         
         [contentView addSubview:headerView];
@@ -143,7 +143,7 @@
     }
     
     
-    CGFloat cellHeight = headerView ? headerView.bounds.size.height + cellPadding : 0;
+    CGFloat cellHeight = headerView ? headerView.bounds.size.height : 0;
     for (int i = 0; i < numberOfColumns; i++) {
         [cellHeightsByColumn addObject:[NSMutableArray arrayWithCapacity:20]];
         [rectsForCells addObject:[NSMutableArray arrayWithCapacity:20]];


### PR DESCRIPTION
The `cellPadding` shouldn't be applied twice to the top of the first cells if there is no header:

![top-padding](https://f.cloud.github.com/assets/3334654/252570/03b108c2-8ba7-11e2-8fac-7dfd0ab2e7c8.png)
