### PR TITLE
Make headerView independent of cellPadding

### DIFF
--- a/EKStreamView.m
+++ b/EKStreamView.m
@@ -112,8 +112,8 @@
     if ([delegate respondsToSelector:@selector(headerForStreamView:)]) {
         headerView = [delegate headerForStreamView:self];
         CGRect f = headerView.frame;
-        f.origin = CGPointMake(columnPadding, cellPadding);
-        f.size.width = self.bounds.size.width - columnPadding * 2;
+        f.origin = CGPointMake(0, 0);
+        f.size.width = self.bounds.size.width;
         headerView.frame = f;
         
         [contentView addSubview:headerView];
@@ -143,7 +143,7 @@
     }
     
     
-    CGFloat cellHeight = headerView ? headerView.bounds.size.height + cellPadding : cellPadding;
+    CGFloat cellHeight = headerView ? headerView.bounds.size.height : 0;
     for (int i = 0; i < numberOfColumns; i++) {
         [cellHeightsByColumn addObject:[NSMutableArray arrayWithCapacity:20]];
         [rectsForCells addObject:[NSMutableArray arrayWithCapacity:20]];


### PR DESCRIPTION
I think it's more flexible if the headerView spans the full width of the view and doesn't have extra padding below it. That way a person can have their header span the full width if they want, or they can still easily get the old behaviour by adding padding to their headerView subviews.
